### PR TITLE
Support custom gitlab username and port for SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unrelease
 
+### Added
+
+* Support custom gitlab username and port for SSH #8
+
 ### Changed
 
 * Switched from `and` to `or` for include pattern in clone command.

--- a/internal/cmd/clone.go
+++ b/internal/cmd/clone.go
@@ -46,7 +46,7 @@ var cloneCmd = &cobra.Command{
 		hoster, err := gitlab.MakeHoster()
 		handleFatalError(err)
 
-		gitclient.PrepareSsh(hoster.Host()) // TODO parse url?
+		gitclient.PrepareSsh(hoster.Host(), config.Values.Gitlab.SSHUser, config.Values.Gitlab.SSHPort)
 		repos := hoster.Repositories(h.RequestOptions{
 			Topics:          cloneTopics,
 			Starred:         cloneStarred,

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -55,7 +55,7 @@ Mode can be one of:
 		gitDirs := collectGitDirsHandled(dirReposRoot, hoster)
 
 		if mode == "fetch" || mode == "pull" {
-			gitclient.PrepareSsh(hoster.Host())
+			gitclient.PrepareSsh(hoster.Host(), config.Values.Gitlab.SSHUser, config.Values.Gitlab.SSHPort)
 		}
 
 		tasks := make(chan *StateContext)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,8 @@ func initLoadDefaults(k *koanf.Koanf) {
 		Gitlab: gitlab{
 			DownloadRetryCount: 6, // lower values didn't solve the issue
 			Host:               "gitlab.com",
+			SSHUser:            "git",
+			SSHPort:            22,
 		},
 	}, "koanf"), nil)
 	print(k, "loaded defaults")

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -23,6 +23,8 @@ type gitlab struct {
 	ApiToken           string `koanf:"apitoken"`
 	DownloadRetryCount int    `koanf:"downloadretrycount"`
 	SecretToken        string `koanf:"secrettoken"`
+	SSHUser            string `koanf:"sshuser"`
+	SSHPort            int    `koanf:"sshport"`
 }
 type slack struct {
 	Token     string `koanf:"token"`

--- a/internal/gitclient/gitclient.go
+++ b/internal/gitclient/gitclient.go
@@ -2,6 +2,7 @@ package gitclient
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,10 +13,10 @@ import (
 	"strings"
 )
 
-func PrepareSsh(host string) {
+func PrepareSsh(host string, sshUser string, sshPort int) {
 	// not sure how to improve this.
 	// maybe load ssh config if available and determine identity for host?
-	_, e, code := util.RunCommandDir(nil, "ssh", "git@"+host)
+	_, e, code := util.RunCommandDir(nil, "ssh", "-p", strconv.Itoa(sshPort), fmt.Sprintf("%s@%s", sshUser, host))
 	if code != 0 {
 		say.Error("Failed loading ssh key: %s", e)
 		os.Exit(3)


### PR DESCRIPTION
This adds support for custom SSH user and port because self hosted Github instances mostly use it