### PR TITLE
Fix empty git bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Shorter apply output, json dump available on verbose
 * Rounded execution times
 
+### Fixed
+
+* Fix `Empty git repository` bug
+* Fix wrong used `path` import for file paths
+
 ## [0.4.3] - 2026-07-30
 
 ### Changed

--- a/internal/cmd/cleanup.go
+++ b/internal/cmd/cleanup.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"repo/internal/config"
 	h "repo/internal/hoster"
@@ -129,8 +128,8 @@ func processDir(dirReposRoot string, hoster h.Hoster, counter *int32, total int,
 func move(dirReposRoot string, dirRepository string, dirTarget string) error {
 	dirRepoRelative := getRelativRepoDir(dirRepository, dirReposRoot)
 	dirAbsSource := dirRepository
-	dirAbsTarget := path.Join(dirReposRoot, dirTarget)
-	dirAbsTargetRepository := path.Join(dirReposRoot, dirTarget, dirRepoRelative)
+	dirAbsTarget := filepath.Join(dirReposRoot, dirTarget)
+	dirAbsTargetRepository := filepath.Join(dirReposRoot, dirTarget, dirRepoRelative)
 
 	// check & prepare target
 	// create if not exists

--- a/internal/cmd/clone.go
+++ b/internal/cmd/clone.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"repo/internal/config"
 	"repo/internal/gitclient"
 	h "repo/internal/hoster"
@@ -67,9 +67,9 @@ func filterExisting(dirReposRoot string, repos []h.HosterRepository) (result []h
 		var dirRepository string
 		switch config.Values.Options.Style {
 		case config.StyleFlat:
-			dirRepository = path.Join(dirReposRoot, r.Path)
+			dirRepository = filepath.Join(dirReposRoot, r.Path)
 		case config.StyleRecursive:
-			dirRepository = path.Join(dirReposRoot, r.PathWithNamespace)
+			dirRepository = filepath.Join(dirReposRoot, r.PathWithNamespace)
 		}
 
 		_, err := os.Stat(dirRepository)

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"math"
 	"os"
-	"path"
 	"path/filepath"
 	h "repo/internal/hoster"
 	"repo/internal/model"
@@ -63,7 +62,7 @@ func validateArgGitDir(argIndex int, repoParent bool, repoRoot bool) cobra.Posit
 		if !util.ExistsDir(repoPath) {
 			return errors.New(msg + " (directory does not exist)")
 		}
-		condParent := repoParent && util.ExistsDir(path.Join(repoPath, ".git"))
+		condParent := repoParent && util.ExistsDir(filepath.Join(repoPath, ".git"))
 		condRoot := repoRoot
 
 		if !condParent && !condRoot {
@@ -77,7 +76,7 @@ func validateArgGitDir(argIndex int, repoParent bool, repoRoot bool) cobra.Posit
 // collect them and return the array
 func collectGitDirs(root string, hoster h.Hoster) (result []model.RepoDir, err error) {
 
-	ignored := []string{path.Join(root, dirArchived), path.Join(root, dirRemoved)}
+	ignored := []string{filepath.Join(root, dirArchived), filepath.Join(root, dirRemoved)}
 
 	walk := func(dir string, d fs.DirEntry, e error) error {
 		if !d.IsDir() {
@@ -88,7 +87,7 @@ func collectGitDirs(root string, hoster h.Hoster) (result []model.RepoDir, err e
 			return fs.SkipDir
 		}
 
-		if util.ExistsDir(path.Join(dir, ".git")) { // check if given path is git-repository
+		if util.ExistsDir(filepath.Join(dir, ".git")) { // check if given path is git-repository
 			repo, err := model.MakeRepoDir(dir, hoster.Host())
 			if err != nil {
 				say.Verbose("Failed determine repository directory: %s", e)

--- a/internal/gitclient/gitclient.go
+++ b/internal/gitclient/gitclient.go
@@ -3,10 +3,9 @@ package gitclient
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"repo/internal/say"
 	"repo/internal/util"
 	"strconv"
@@ -24,7 +23,7 @@ func PrepareSsh(host string, sshUser string, sshPort int) {
 }
 
 func Clone(rootDir string, repoDir string, sshUrl string) error {
-	dirRepository := path.Join(rootDir, repoDir)
+	dirRepository := filepath.Join(rootDir, repoDir)
 	cmdGo := exec.Command("git", "clone", sshUrl, dirRepository)
 	if say.VerboseEnabled {
 		cmdGo.Stdout = os.Stdout
@@ -53,18 +52,18 @@ func GetLocalChanges(repoDir string) string {
 }
 
 func IsEmpty(repoDir string) bool {
-	fis, err := ioutil.ReadDir(path.Join(repoDir, ".git/objects"))
+	gitDir := filepath.Join(repoDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return true
+	}
+
+	refsHeads := filepath.Join(gitDir, "refs", "heads")
+	entries, err := os.ReadDir(refsHeads)
 	if err != nil {
 		return true
 	}
-	for _, fi := range fis {
-		if !fi.IsDir() {
-			return true
-		}
-	}
-	return false
-	//o, _, _ := util.RunCommandDir(&repoDir, "find", ".git/objects", "-type", "f")
-	//return len(o) == 0
+
+	return len(entries) == 0
 }
 
 func GetCurrentBranch(repoDir string) string {

--- a/internal/model/repo.go
+++ b/internal/model/repo.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"regexp"
 	"repo/internal/say"
 	"repo/internal/util"
@@ -30,7 +30,7 @@ type RepoRemote struct {
 }
 
 func (rd RepoDir) RepoYamlFilename() string {
-	return path.Join(rd.Path, RepoYamlFilename)
+	return filepath.Join(rd.Path, RepoYamlFilename)
 }
 
 func (rd RepoDir) PathDirName() string {


### PR DESCRIPTION
Git 2.47.0 introduced a new feature which spawns a detached `git maintenance run` in the background. This can result in
a problem because it creates a `maintenance.lock` file.
The current `IsEmpty` implementation then interprets that incorrectly.

One option is to disable this with the config `maintenance.auto=false` but I think it's more safe to just check if `.git` exists and contains at least one commit ref.

But we should keep that feature in mind when using concurrency on the same repository!

See also https://github.com/argoproj/argo-cd/issues/25101